### PR TITLE
Fixes running OSX executable on other systems

### DIFF
--- a/src/BuildExecutable.jl
+++ b/src/BuildExecutable.jl
@@ -176,6 +176,7 @@ function build_executable(exename, script_file, targetdir=nothing, cpu_target="n
                 # For debug purpose
                 #println(readall(`otool -L $(joinpath(targetdir, shlib))`)[1:end-1])
                 #println("sys.buildfile=",sys.buildfile)
+                run(`$(patchelf) -rpath $(sys.buildpath) @executable_path $(joinpath(targetdir, shlib))`)
                 run(`$(patchelf) -change $(sys.buildfile).$(Libdl.dlext) @executable_path/$(basename(sys.buildfile)).$(Libdl.dlext) $(joinpath(targetdir, shlib))`)
                 #println(readall(`otool -L $(joinpath(targetdir, shlib))`)[1:end-1])
             end


### PR DESCRIPTION
by setting the `@rpath` to the `@executable_path`
rather than the host julia install directory.

handles issue #11 for OSX
