### PR TITLE
loosen Compat minimum version requirement to 0.7.20

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.4
 BinDeps
-Compat 0.14
+Compat 0.7.20
 @windows WinRPM


### PR DESCRIPTION
this should be enough for `is_windows()` etc https://github.com/JuliaLang/Compat.jl/commit/85f886227c332507ec5b31627e0b3a9fbb6aa274
`@static` was released in the preceding version 0.7.19