### PR TITLE
Minor changes to support julia 0.6 and nightly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
   - nightly
 addons:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.5
 BinDeps
 Compat 0.7.20
 @windows WinRPM

--- a/src/BuildExecutable.jl
+++ b/src/BuildExecutable.jl
@@ -300,7 +300,8 @@ function emit_cmain(cfile, exename, relocation)
             int ret = 0;
             if (jl_exception_occurred())
             {
-                jl_show(jl_stderr_obj(), jl_exception_occurred());
+                // jl_show(jl_stderr_obj(), jl_exception_occurred());
+                jl_call2(jl_get_function(jl_base_module, "show"), jl_stderr_obj(), jl_exception_occurred());
                 jl_printf(jl_stderr_stream(), "\\n");
                 ret = 1;
             }


### PR DESCRIPTION
* Fixed deprecated `@unix_only` and `@windows_only` syntax
* Fixed missing `jl_show` in start_func.c
* Removed support for 0.4 (NOTE: I can undo this, but it'll be a little ugly to support the fixes.)